### PR TITLE
Correcting the yang key safe_name logic

### DIFF
--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -1541,7 +1541,7 @@ def get_element(ctx, fd, element, module, parent, path, parent_cfg=True, choice=
             # ordered.
             if element.keyword == "list":
                 elemdict["key"] = (
-                    safe_name(element.search_one("key").arg) if element.search_one("key") is not None else False
+                    " ".join([safe_name(key) for key in element.search_one("key").arg.split(" ")]) if element.search_one("key") is not None else False
                 )
                 elemdict["yang_keys"] = (
                     element.search_one("key").arg if element.search_one("key") is not None else False


### PR DESCRIPTION
Fixed this issue in pyangbind and created the pull request , please review. Space separated strings are not converted by the safe_name, so converting individually by split.